### PR TITLE
Fix Json Parser for Non-Judger Model

### DIFF
--- a/run_scene_eval.py
+++ b/run_scene_eval.py
@@ -134,14 +134,14 @@ def eval_models_pairwise(model_1, model_2):
             )
 
             try:
-                parsed_model_a_response = extract_and_parse_json(model_a_response)
+                parsed_model_a_response = extract_and_parse_json(model_a_response, is_judger=False)
                 model_a_end = parsed_model_a_response["is_chat_finished"]
             except:
                 model_a_end = False
                 print(f"Warning: Format error in response of {model_a}")
                 print(model_a_response)
             try:
-                parsed_model_b_response = extract_and_parse_json(model_b_response)
+                parsed_model_b_response = extract_and_parse_json(model_b_response, is_judger=False)
                 model_b_end = parsed_model_b_response["is_chat_finished"]
             except:
                 model_b_end = False

--- a/utils.py
+++ b/utils.py
@@ -35,13 +35,17 @@ OPENAI_MODEL_LIST = (
 )
 
 
-def extract_and_parse_json(text):
+def extract_and_parse_json(text, is_judger=True):
     pattern = r"```json\s+(.+?)\s+```"
     match = re.search(pattern, text, re.DOTALL)
     if match:
         json_str = match.group(1)
     else:
         json_str = text
+
+    if not is_judger:
+        # skip winner field check for non-judger model
+        return json_repair.loads(text)
 
     try:
         parsed_obj = json_repair.loads(json_str)


### PR DESCRIPTION
Thanks for open sourcing the benchmark, great work!

When I run the scene evaluation, the candidate models always gives formatting error, as "winner" is not an attribute in their response format. This causes "is_chat_finished" to be never used. This PR fixes this issue.

Appreciate any feedback and suggestion!
