### PR TITLE
Fix message order by moving greeting to system context (Issue #7) Move greeting to system context

### DIFF
--- a/run_character_eval.py
+++ b/run_character_eval.py
@@ -29,6 +29,12 @@ $definition_text
 
 ## Long Definition
 $long_definition_text
+
+# Scenario Context:
+The conversation begins with the following situation:
+$greeting
+
+You should respond naturally to the user's messages while staying in character.
 """
 )
 
@@ -98,9 +104,8 @@ def eval_models_pairwise(model_1, model_2):
         candidate_messages = [
             {
                 "role": "system",
-                "content": TEMPLATE.substitute(background=background, **npc_profile),
+                "content": TEMPLATE.substitute(background=background, greeting=greeting, **npc_profile),
             },
-            {"role": "assistant", "content": greeting},
         ]
 
         judger_messages = [

--- a/run_scene_eval.py
+++ b/run_scene_eval.py
@@ -30,6 +30,10 @@ $progression
 # NPC Status:
 $npc_status
 
+# Scenario Context:
+The scene begins with the following situation:
+$greeting
+
 You are an AI NPC for a role-play game. Based on the previous information, you will play a NPC character in the scene.
 Reply in this JSON format: {"npc_speaks": "YOUR RESPONSE", "is_chat_finished": true or false}. If the scene is finished and ready to move on, set "is_chat_finished" to true. Otherwise, set it to false.
 """
@@ -101,9 +105,8 @@ def eval_models_pairwise(model_1, model_2):
         candidate_messages = [
             {
                 "role": "system",
-                "content": TEMPLATE.substitute(d),
+                "content": TEMPLATE.substitute(greeting=greeting, **d),
             },
-            {"role": "assistant", "content": greeting},
         ]
 
         judger_messages = [


### PR DESCRIPTION
Fixes #7

## Problem
The current implementation sends messages in an unconventional order:
- System message
- Assistant message (greeting) 
- User message

This violates the standard LLM conversation pattern and may cause suboptimal performance in some models.

## Solution
Move the greeting from a separate assistant message into the system message as scenario context.

**Before:**
- System: NPC profile
- Assistant: greeting
- User: first input

**After:**
- System: NPC profile + greeting as scenario context
- User: first input
- Assistant: model response

## Changes
- `run_character_eval.py`: Updated TEMPLATE to include greeting, removed assistant message
- `run_scene_eval.py`: Updated TEMPLATE to include greeting, removed assistant message

## Trade-offs
- Pros: Clean message structure, follows LLM best practices, no artificial messages
- Cons: Slight semantic change (greeting becomes context rather than conversation history)

## Testing
- No syntax errors
- No diagnostics
- Evaluation flow preserved
- Greeting content unchanged (still pre-defined)

## Note
I have also prepared an alternative approach (Option 2) in branch `fix-message-order-option2` that adds a dummy user message instead. Both are valid solutions - this option is cleaner but Option 2 preserves semantics better. Happy to discuss which approach you prefer.