### PR TITLE
Fix message order with dummy user message (Issue #7 - Alternative) Fix message order with dummy user message

### DIFF
--- a/run_character_eval.py
+++ b/run_character_eval.py
@@ -100,6 +100,7 @@ def eval_models_pairwise(model_1, model_2):
                 "role": "system",
                 "content": TEMPLATE.substitute(background=background, **npc_profile),
             },
+            {"role": "user", "content": "[Begin the roleplay scenario]"},
             {"role": "assistant", "content": greeting},
         ]
 

--- a/run_scene_eval.py
+++ b/run_scene_eval.py
@@ -103,6 +103,7 @@ def eval_models_pairwise(model_1, model_2):
                 "role": "system",
                 "content": TEMPLATE.substitute(d),
             },
+            {"role": "user", "content": "[Begin the roleplay scenario]"},
             {"role": "assistant", "content": greeting},
         ]
 


### PR DESCRIPTION
Fixes #7

## Problem
The current implementation sends messages in an unconventional order:
- System message
- Assistant message (greeting)
- User message

This violates the standard LLM conversation pattern and may cause suboptimal performance in some models.

## Solution
Add a dummy user message before the greeting to maintain proper message order while preserving original semantics.

**Before:**
- System: NPC profile
- Assistant: greeting
- User: first input

**After:**
- System: NPC profile
- User: "[Begin the roleplay scenario]"
- Assistant: greeting
- User: first real input
- Assistant: model response

## Changes
- `run_character_eval.py`: Added dummy user message
- `run_scene_eval.py`: Added dummy user message

## Trade-offs
- Pros: Preserves original semantics, greeting stays in conversation history, minimal risk
- Cons: Adds one artificial message

## Testing
- No syntax errors
- No diagnostics
- Evaluation flow preserved
- Greeting content unchanged (still pre-defined)

## Note
This is an alternative to PR #8 (Option 1). Option 1 is cleaner but this option preserves semantics better. Both are valid solutions - please choose whichever fits your preferences.
